### PR TITLE
Use CODESIGN_ALLOCATE Bash Var if Available

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>org.hardisonbrewing</groupId>
 	<artifactId>maven-cxx-plugin</artifactId>
 	<!-- forked from 1.1.17 -->
-	<version>1.1.17.1.metova</version>
+	<version>1.1.17.2.metova-SNAPSHOT</version>
 	<packaging>maven-plugin</packaging>
 	<name>${project.artifactId}</name>
 	<build>
@@ -109,13 +109,13 @@
 		</dependency>
 	</dependencies>
 	<distributionManagement>
-<!-- 		<repository> -->
-<!-- 			<id>metova-licensed-snapshots</id> -->
-<!-- 			<url>http://repo.metova.com/nexus/content/repositories/licensed-snapshots</url> -->
-<!-- 		</repository> -->
 		<repository>
-			<id>hardisonbrewing-releases</id>
-			<url>http://repo.hardisonbrewing.org/nexus/content/repositories/releases</url>
+			<id>metova-licensed-snapshots</id>
+			<url>http://repo.metova.com/nexus/content/repositories/licensed-snapshots</url>
 		</repository>
+<!-- 		<repository> -->
+<!-- 			<id>hardisonbrewing-releases</id> -->
+<!-- 			<url>http://repo.hardisonbrewing.org/nexus/content/repositories/releases</url> -->
+<!-- 		</repository> -->
 	</distributionManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,8 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.hardisonbrewing</groupId>
 	<artifactId>maven-cxx-plugin</artifactId>
-	<version>1.1.18.metova-SNAPSHOT</version>
+	<!-- forked from 1.1.17 -->
+	<version>1.1.17.1.metova</version>
 	<packaging>maven-plugin</packaging>
 	<name>${project.artifactId}</name>
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
 		<dependency>
 			<groupId>org.hardisonbrewing</groupId>
 			<artifactId>hbc-maven-core</artifactId>
-			<version>1.0.7</version>
+			<version>1.0.8-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>org.hardisonbrewing</groupId>
 	<artifactId>maven-cxx-plugin</artifactId>
 	<!-- forked from 1.1.17 -->
-	<version>1.1.17.2.metova-SNAPSHOT</version>
+	<version>1.1.17.2.metova</version>
 	<packaging>maven-plugin</packaging>
 	<name>${project.artifactId}</name>
 	<build>
@@ -109,13 +109,13 @@
 		</dependency>
 	</dependencies>
 	<distributionManagement>
-		<repository>
-			<id>metova-licensed-snapshots</id>
-			<url>http://repo.metova.com/nexus/content/repositories/licensed-snapshots</url>
-		</repository>
 <!-- 		<repository> -->
-<!-- 			<id>hardisonbrewing-releases</id> -->
-<!-- 			<url>http://repo.hardisonbrewing.org/nexus/content/repositories/releases</url> -->
+<!-- 			<id>metova-licensed-snapshots</id> -->
+<!-- 			<url>http://repo.metova.com/nexus/content/repositories/licensed-snapshots</url> -->
 <!-- 		</repository> -->
+		<repository>
+			<id>hardisonbrewing-releases</id>
+			<url>http://repo.hardisonbrewing.org/nexus/content/repositories/releases</url>
+		</repository>
 	</distributionManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,8 +3,8 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.hardisonbrewing</groupId>
 	<artifactId>maven-cxx-plugin</artifactId>
-	<!-- forked from 1.1.17 -->
-	<version>1.1.17.3.metova-SNAPSHOT</version>
+	<!-- forked from 1.1.18 -->
+	<version>1.1.18.1.metova-SNAPSHOT</version>
 	<packaging>maven-plugin</packaging>
 	<name>${project.artifactId}</name>
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>org.hardisonbrewing</groupId>
 	<artifactId>maven-cxx-plugin</artifactId>
 	<!-- forked from 1.1.17 -->
-	<version>1.1.17.2.metova</version>
+	<version>1.1.17.3.metova-SNAPSHOT</version>
 	<packaging>maven-plugin</packaging>
 	<name>${project.artifactId}</name>
 	<build>
@@ -109,13 +109,13 @@
 		</dependency>
 	</dependencies>
 	<distributionManagement>
-<!-- 		<repository> -->
-<!-- 			<id>metova-licensed-snapshots</id> -->
-<!-- 			<url>http://repo.metova.com/nexus/content/repositories/licensed-snapshots</url> -->
-<!-- 		</repository> -->
 		<repository>
-			<id>hardisonbrewing-releases</id>
-			<url>http://repo.hardisonbrewing.org/nexus/content/repositories/releases</url>
+			<id>metova-licensed-snapshots</id>
+			<url>http://repo.metova.com/nexus/content/repositories/licensed-snapshots</url>
 		</repository>
+<!-- 		<repository> -->
+<!-- 			<id>hardisonbrewing-releases</id> -->
+<!-- 			<url>http://repo.hardisonbrewing.org/nexus/content/repositories/releases</url> -->
+<!-- 		</repository> -->
 	</distributionManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -109,13 +109,13 @@
 		</dependency>
 	</dependencies>
 	<distributionManagement>
-		<repository>
-			<id>metova-licensed-snapshots</id>
-			<url>http://repo.metova.com/nexus/content/repositories/licensed-snapshots</url>
-		</repository>
 <!-- 		<repository> -->
-<!-- 			<id>hardisonbrewing-releases</id> -->
-<!-- 			<url>http://repo.hardisonbrewing.org/nexus/content/repositories/releases</url> -->
+<!-- 			<id>metova-licensed-snapshots</id> -->
+<!-- 			<url>http://repo.metova.com/nexus/content/repositories/licensed-snapshots</url> -->
 <!-- 		</repository> -->
+		<repository>
+			<id>hardisonbrewing-releases</id>
+			<url>http://repo.hardisonbrewing.org/nexus/content/repositories/releases</url>
+		</repository>
 	</distributionManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>org.hardisonbrewing</groupId>
 	<artifactId>maven-cxx-plugin</artifactId>
 	<!-- forked from 1.1.18 -->
-	<version>1.1.18.1.metova</version>
+	<version>1.1.18.2.metova-SNAPSHOT</version>
 	<packaging>maven-plugin</packaging>
 	<name>${project.artifactId}</name>
 	<build>
@@ -109,13 +109,13 @@
 		</dependency>
 	</dependencies>
 	<distributionManagement>
-<!-- 		<repository> -->
-<!-- 			<id>metova-licensed-snapshots</id> -->
-<!-- 			<url>http://repo.metova.com/nexus/content/repositories/licensed-snapshots</url> -->
-<!-- 		</repository> -->
 		<repository>
-			<id>hardisonbrewing-releases</id>
-			<url>http://repo.hardisonbrewing.org/nexus/content/repositories/releases</url>
+			<id>metova-licensed-snapshots</id>
+			<url>http://repo.metova.com/nexus/content/repositories/licensed-snapshots</url>
 		</repository>
+<!-- 		<repository> -->
+<!-- 			<id>hardisonbrewing-releases</id> -->
+<!-- 			<url>http://repo.hardisonbrewing.org/nexus/content/repositories/releases</url> -->
+<!-- 		</repository> -->
 	</distributionManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.hardisonbrewing</groupId>
 	<artifactId>maven-cxx-plugin</artifactId>
-	<version>1.1.18-SNAPSHOT</version>
+	<version>1.1.18.metova-SNAPSHOT</version>
 	<packaging>maven-plugin</packaging>
 	<name>${project.artifactId}</name>
 	<build>
@@ -84,7 +84,7 @@
 		<dependency>
 			<groupId>org.hardisonbrewing</groupId>
 			<artifactId>hbc-maven-core</artifactId>
-			<version>1.0.8-SNAPSHOT</version>
+			<version>1.0.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>
@@ -109,8 +109,8 @@
 	</dependencies>
 	<distributionManagement>
 		<repository>
-			<id>hardisonbrewing-snapshots</id>
-			<url>http://repo.hardisonbrewing.org/nexus/content/repositories/snapshots</url>
+			<id>metova-licensed-snapshots</id>
+			<url>http://repo.metova.com/nexus/content/repositories/licensed-snapshots</url>
 		</repository>
 <!-- 		<repository> -->
 <!-- 			<id>hardisonbrewing-releases</id> -->

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>org.hardisonbrewing</groupId>
 	<artifactId>maven-cxx-plugin</artifactId>
 	<!-- forked from 1.1.18 -->
-	<version>1.1.18.1.metova-SNAPSHOT</version>
+	<version>1.1.18.1.metova</version>
 	<packaging>maven-plugin</packaging>
 	<name>${project.artifactId}</name>
 	<build>
@@ -109,13 +109,13 @@
 		</dependency>
 	</dependencies>
 	<distributionManagement>
-		<repository>
-			<id>metova-licensed-snapshots</id>
-			<url>http://repo.metova.com/nexus/content/repositories/licensed-snapshots</url>
-		</repository>
 <!-- 		<repository> -->
-<!-- 			<id>hardisonbrewing-releases</id> -->
-<!-- 			<url>http://repo.hardisonbrewing.org/nexus/content/repositories/releases</url> -->
+<!-- 			<id>metova-licensed-snapshots</id> -->
+<!-- 			<url>http://repo.metova.com/nexus/content/repositories/licensed-snapshots</url> -->
 <!-- 		</repository> -->
+		<repository>
+			<id>hardisonbrewing-releases</id>
+			<url>http://repo.hardisonbrewing.org/nexus/content/repositories/releases</url>
+		</repository>
 	</distributionManagement>
 </project>

--- a/src/main/java/org/hardisonbrewing/maven/cxx/bar/PropertiesService.java
+++ b/src/main/java/org/hardisonbrewing/maven/cxx/bar/PropertiesService.java
@@ -16,57 +16,17 @@
  */
 package org.hardisonbrewing.maven.cxx.bar;
 
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Properties;
-
 public class PropertiesService extends org.hardisonbrewing.maven.cxx.PropertiesService {
 
-    public static final String ADOBE_FLEX_HOME;
-    public static final String BLACKBERRY_WEBWORKS_TABLET_HOME;
-    public static final String BLACKBERRY_TABLET_HOME;
-    public static final String BLACKBERRY_TABLET_DEVICE_IP;
-    public static final String BLACKBERRY_TABLET_DEVICE_PASSWORD;
-    public static final String DEBUG;
-
-    private static final String[] properties;
-
-    static {
-
-        List<String> keys = new LinkedList<String>();
-        keys.add( ADOBE_FLEX_HOME = "adobe.flex.home" );
-        keys.add( BLACKBERRY_WEBWORKS_TABLET_HOME = "blackberry.webworks.tablet.home" );
-        keys.add( BLACKBERRY_TABLET_HOME = "blackberry.tablet.home" );
-        keys.add( BLACKBERRY_TABLET_DEVICE_IP = "blackberry.tablet.device.ip" );
-        keys.add( BLACKBERRY_TABLET_DEVICE_PASSWORD = "blackberry.tablet.device.password" );
-        keys.add( DEBUG = "debug" );
-
-        properties = new String[keys.size()];
-        keys.toArray( properties );
-    }
+    public static final String ADOBE_FLEX_HOME = "adobe.flex.home";
+    public static final String BLACKBERRY_WEBWORKS_TABLET_HOME = "blackberry.webworks.tablet.home";
+    public static final String BLACKBERRY_TABLET_HOME = "blackberry.tablet.home";
+    public static final String BLACKBERRY_TABLET_DEVICE_IP = "blackberry.tablet.device.ip";
+    public static final String BLACKBERRY_TABLET_DEVICE_PASSWORD = "blackberry.tablet.device.password";
+    public static final String DEBUG = "debug";
 
     protected PropertiesService() {
 
         // do nothing
-    }
-
-    public static final boolean propertiesHaveChanged() {
-
-        if ( pluginVersionsHaveChanged() ) {
-            return true;
-        }
-
-        Properties properties = loadBuildDifferenceProperties();
-        if ( properties == null ) {
-            return false;
-        }
-
-        for (String key : PropertiesService.properties) {
-            if ( "true".equalsIgnoreCase( (String) properties.get( key ) ) ) {
-                return true;
-            }
-        }
-
-        return false;
     }
 }

--- a/src/main/java/org/hardisonbrewing/maven/cxx/bar/flex/BarCompileMojo.java
+++ b/src/main/java/org/hardisonbrewing/maven/cxx/bar/flex/BarCompileMojo.java
@@ -39,12 +39,6 @@ public class BarCompileMojo extends JoJoMojoImpl {
     public void execute() throws MojoExecutionException, MojoFailureException {
 
         String artifactId = getProject().getArtifactId();
-
-        if ( !shouldExecute() ) {
-            getLog().info( artifactId + ".bar is up-to-date, not rebuilding!" );
-            return;
-        }
-
         getLog().info( "Building " + artifactId + ".bar..." );
 
         List<String> cmd = new LinkedList<String>();
@@ -74,48 +68,5 @@ public class BarCompileMojo extends JoJoMojoImpl {
         Commandline commandLine = buildCommandline( cmd );
         CommandLineService.addTabletEnvVars( commandLine );
         execute( commandLine );
-    }
-
-    private final boolean shouldExecute() {
-
-        String barFileName = getProject().getArtifactId() + ".bar";
-
-        if ( PropertiesService.propertiesHaveChanged() ) {
-            getLog().info( "Properties have changed, rebuilding " + barFileName + "..." );
-            return true;
-        }
-
-        StringBuffer outputPath = new StringBuffer();
-        outputPath.append( TargetDirectoryService.getTargetDirectoryPath() );
-        outputPath.append( File.separator );
-        outputPath.append( barFileName );
-
-        File outputFile = new File( outputPath.toString() );
-        if ( outputFile.exists() ) {
-            if ( outputFile.lastModified() >= getLatestFileDate() ) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    private final long getLatestFileDate() {
-
-        String artifactId = getProject().getArtifactId();
-        long artifactXml = getLatestFileDate( artifactId + ".xml" );
-        long artifactSwf = getLatestFileDate( artifactId + ".swf" );
-        return Math.max( artifactXml, artifactSwf );
-    }
-
-    private final long getLatestFileDate( String filename ) {
-
-        StringBuffer sourcePath = new StringBuffer();
-        sourcePath.append( TargetDirectoryService.getTargetDirectoryPath() );
-        sourcePath.append( File.separator );
-        sourcePath.append( filename );
-
-        File sourceFile = new File( sourcePath.toString() );
-        return sourceFile.lastModified();
     }
 }

--- a/src/main/java/org/hardisonbrewing/maven/cxx/bar/flex/mxml/ProcessResourcesMojo.java
+++ b/src/main/java/org/hardisonbrewing/maven/cxx/bar/flex/mxml/ProcessResourcesMojo.java
@@ -39,12 +39,6 @@ public class ProcessResourcesMojo extends JoJoMojoImpl {
     public void execute() throws MojoExecutionException, MojoFailureException {
 
         String artifactId = getProject().getArtifactId();
-
-        if ( !shouldExecute() ) {
-            getLog().info( artifactId + ".swc is up-to-date, not rebuilding!" );
-            return;
-        }
-
         getLog().info( "Building " + artifactId + ".swc..." );
 
         List<String> cmd = new LinkedList<String>();
@@ -75,44 +69,5 @@ public class ProcessResourcesMojo extends JoJoMojoImpl {
         Commandline commandLine = buildCommandline( cmd );
         CommandLineService.appendEnvVar( commandLine, "PATH", sdkHome + File.separator + "bin" );
         execute( commandLine );
-    }
-
-    protected final boolean shouldExecute() {
-
-        String swcFileName = getProject().getArtifactId() + ".swc";
-
-        if ( PropertiesService.propertiesHaveChanged() ) {
-            getLog().info( "Properties have changed, rebuilding " + swcFileName + "..." );
-            return true;
-        }
-
-        StringBuffer outputPath = new StringBuffer();
-        outputPath.append( TargetDirectoryService.getTargetDirectoryPath() );
-        outputPath.append( File.separator );
-        outputPath.append( swcFileName );
-
-        File outputFile = new File( outputPath.toString() );
-        if ( outputFile.exists() ) {
-            if ( outputFile.lastModified() >= getLatestFileDate() ) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    private final long getLatestFileDate() {
-
-        long lastModified = 0;
-        for (String filePath : TargetDirectoryService.getResourceFilePaths()) {
-            lastModified = Math.max( lastModified, getLatestFileDate( filePath ) );
-        }
-        return lastModified;
-    }
-
-    private final long getLatestFileDate( String filePath ) {
-
-        File sourceFile = new File( filePath );
-        return FileUtils.lastModified( sourceFile, false );
     }
 }

--- a/src/main/java/org/hardisonbrewing/maven/cxx/bar/js/BarCompileMojo.java
+++ b/src/main/java/org/hardisonbrewing/maven/cxx/bar/js/BarCompileMojo.java
@@ -38,12 +38,6 @@ public class BarCompileMojo extends JoJoMojoImpl {
     public void execute() throws MojoExecutionException, MojoFailureException {
 
         String artifactId = getProject().getArtifactId();
-
-        if ( !shouldExecute() ) {
-            getLog().info( artifactId + ".bar is up-to-date, not rebuilding!" );
-            return;
-        }
-
         getLog().info( "Building " + artifactId + ".bar..." );
 
         List<String> cmd = new LinkedList<String>();
@@ -82,46 +76,5 @@ public class BarCompileMojo extends JoJoMojoImpl {
         File destBarFile = new File( destBarPath.toString() );
 
         srcBarFile.renameTo( destBarFile );
-    }
-
-    private final boolean shouldExecute() {
-
-        String barFileName = getProject().getArtifactId() + ".bar";
-
-        if ( PropertiesService.propertiesHaveChanged() ) {
-            getLog().info( "Properties have changed, rebuilding " + barFileName + "..." );
-            return true;
-        }
-
-        StringBuffer outputPath = new StringBuffer();
-        outputPath.append( TargetDirectoryService.getTargetDirectoryPath() );
-        outputPath.append( File.separator );
-        outputPath.append( barFileName );
-
-        File outputFile = new File( outputPath.toString() );
-        if ( outputFile.exists() ) {
-            if ( outputFile.lastModified() >= getLatestFileDate() ) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    private final long getLatestFileDate() {
-
-        String artifactId = getProject().getArtifactId();
-        return getLatestFileDate( artifactId + ".zip" );
-    }
-
-    private final long getLatestFileDate( String filename ) {
-
-        StringBuffer sourcePath = new StringBuffer();
-        sourcePath.append( TargetDirectoryService.getTargetDirectoryPath() );
-        sourcePath.append( File.separator );
-        sourcePath.append( filename );
-
-        File sourceFile = new File( sourcePath.toString() );
-        return sourceFile.lastModified();
     }
 }

--- a/src/main/java/org/hardisonbrewing/maven/cxx/flex/AirCompileMojo.java
+++ b/src/main/java/org/hardisonbrewing/maven/cxx/flex/AirCompileMojo.java
@@ -25,9 +25,7 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.codehaus.plexus.util.cli.Commandline;
 import org.hardisonbrewing.maven.core.JoJoMojoImpl;
 import org.hardisonbrewing.maven.core.ProjectService;
-import org.hardisonbrewing.maven.core.cli.CommandLineService;
 import org.hardisonbrewing.maven.cxx.TargetDirectoryService;
-import org.hardisonbrewing.maven.cxx.bar.PropertiesService;
 
 /**
  * @goal flex-air-compile
@@ -112,10 +110,8 @@ public class AirCompileMojo extends JoJoMojoImpl {
         airiFilePath.append( ".airi" );
         cmd.add( airiFilePath.toString() );
 
-        String sdkHome = PropertiesService.getProperty( PropertiesService.ADOBE_FLEX_HOME );
-
         Commandline commandLine = buildCommandline( cmd );
-        CommandLineService.appendEnvVar( commandLine, "PATH", sdkHome + File.separator + "bin" );
+        CommandLineService.addFlexEnvVars( commandLine );
         execute( commandLine );
     }
 

--- a/src/main/java/org/hardisonbrewing/maven/cxx/flex/AiriCompileMojo.java
+++ b/src/main/java/org/hardisonbrewing/maven/cxx/flex/AiriCompileMojo.java
@@ -25,9 +25,7 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.codehaus.plexus.util.cli.Commandline;
 import org.hardisonbrewing.maven.core.JoJoMojoImpl;
 import org.hardisonbrewing.maven.core.ProjectService;
-import org.hardisonbrewing.maven.core.cli.CommandLineService;
 import org.hardisonbrewing.maven.cxx.TargetDirectoryService;
-import org.hardisonbrewing.maven.cxx.bar.PropertiesService;
 
 /**
  * @goal flex-airi-compile
@@ -79,10 +77,8 @@ public class AiriCompileMojo extends JoJoMojoImpl {
         cmd.add( targetDirectoryPath );
         cmd.add( getSourceName() + ".swf" );
 
-        String sdkHome = PropertiesService.getProperty( PropertiesService.ADOBE_FLEX_HOME );
-
         Commandline commandLine = buildCommandline( cmd );
-        CommandLineService.appendEnvVar( commandLine, "PATH", sdkHome + File.separator + "bin" );
+        CommandLineService.addFlexEnvVars( commandLine );
         execute( commandLine );
     }
 

--- a/src/main/java/org/hardisonbrewing/maven/cxx/flex/CommandLineService.java
+++ b/src/main/java/org/hardisonbrewing/maven/cxx/flex/CommandLineService.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2012 Martin M Reed
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.hardisonbrewing.maven.cxx.flex;
+
+import java.io.File;
+
+import org.apache.commons.cli.CommandLine;
+import org.codehaus.plexus.util.cli.Commandline;
+
+/**
+ * Utility methods for handling {@link CommandLine} execution.
+ */
+public class CommandLineService extends org.hardisonbrewing.maven.core.cli.CommandLineService {
+
+    protected CommandLineService() {
+
+        // do nothing
+    }
+
+    public static void addFlexEnvVars( Commandline commandLine ) {
+
+        String sdkHome = PropertiesService.getProperty( PropertiesService.ADOBE_FLEX_HOME );
+
+        if ( sdkHome == null ) {
+            return;
+        }
+
+        StringBuffer qnxHostBinDirPath = new StringBuffer();
+        qnxHostBinDirPath.append( sdkHome );
+        qnxHostBinDirPath.append( File.separator );
+        qnxHostBinDirPath.append( "bin" );
+        appendEnvVar( commandLine, "PATH", qnxHostBinDirPath.toString() );
+    }
+}

--- a/src/main/java/org/hardisonbrewing/maven/cxx/flex/FlexService.java
+++ b/src/main/java/org/hardisonbrewing/maven/cxx/flex/FlexService.java
@@ -16,6 +16,11 @@
  */
 package org.hardisonbrewing.maven.cxx.flex;
 
+import java.io.File;
+import java.util.List;
+
+import org.hardisonbrewing.maven.core.ProjectService;
+
 public class FlexService {
 
     public static final String[] NON_RESOURCE_EXTS = new String[] { "**/*.as", "**/*.mxml" };
@@ -37,5 +42,37 @@ public class FlexService {
     public static final boolean isAndroidTarget( String target ) {
 
         return target.startsWith( ANDROID_TARGET_EXT );
+    }
+
+    public static void addConfig( List<String> cmd, String config, String target ) {
+
+        String configPath = config;
+
+        if ( configPath == null || configPath.length() == 0 ) {
+
+            String sdkHome = PropertiesService.getProperty( PropertiesService.ADOBE_FLEX_HOME );
+
+            StringBuffer stringBuffer = new StringBuffer();
+            stringBuffer.append( sdkHome );
+            stringBuffer.append( File.separator );
+            stringBuffer.append( "frameworks" );
+            stringBuffer.append( File.separator );
+            if ( FlexService.isIosTarget( target ) || FlexService.isAndroidTarget( target ) ) {
+                stringBuffer.append( "airmobile-config.xml" );
+            }
+            else {
+                stringBuffer.append( "air-config.xml" );
+            }
+            configPath = stringBuffer.toString();
+        }
+        else if ( !configPath.startsWith( File.separator ) ) {
+            StringBuffer stringBuffer = new StringBuffer();
+            stringBuffer.append( ProjectService.getBaseDirPath() );
+            stringBuffer.append( File.separator );
+            stringBuffer.append( configPath );
+            configPath = stringBuffer.toString();
+        }
+        cmd.add( "-load-config" );
+        cmd.add( configPath );
     }
 }

--- a/src/main/java/org/hardisonbrewing/maven/cxx/flex/InitializeMojo.java
+++ b/src/main/java/org/hardisonbrewing/maven/cxx/flex/InitializeMojo.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2012 Martin M Reed
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.hardisonbrewing.maven.cxx.flex;
+
+import java.util.Properties;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.hardisonbrewing.maven.core.JoJoMojoImpl;
+
+/**
+ * @goal flex-initialize
+ * @phase initialize
+ */
+public class InitializeMojo extends JoJoMojoImpl {
+
+    /**
+     * @parameter
+     */
+    private String target;
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+
+        Properties properties = PropertiesService.getFlexProperties();
+        properties.put( "target", target );
+        PropertiesService.storeFlexProperties( properties );
+    }
+}

--- a/src/main/java/org/hardisonbrewing/maven/cxx/flex/PropertiesService.java
+++ b/src/main/java/org/hardisonbrewing/maven/cxx/flex/PropertiesService.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2012 Martin M Reed
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.hardisonbrewing.maven.cxx.flex;
+
+import java.io.File;
+import java.util.Properties;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.project.MavenProject;
+import org.hardisonbrewing.maven.core.JoJoMojo;
+import org.hardisonbrewing.maven.cxx.TargetDirectoryService;
+
+public class PropertiesService extends org.hardisonbrewing.maven.cxx.PropertiesService {
+
+    private static Properties properties;
+
+    protected PropertiesService() {
+
+        // do nothing
+    }
+
+    public static final Properties getFlexProperties() {
+
+        if ( properties == null ) {
+            properties = loadProperties( getFlexPropertiesPath() );
+        }
+        if ( properties == null ) {
+            Properties properties = new Properties();
+            storeFlexProperties( properties );
+            PropertiesService.properties = properties;
+        }
+        return properties;
+    }
+
+    public static final String getFlexPropertiesPath() {
+
+        MavenProject project = JoJoMojo.getMojo().getProject();
+        Artifact artifact = project.getArtifact();
+
+        StringBuffer stringBuffer = new StringBuffer();
+        stringBuffer.append( TargetDirectoryService.getTargetDirectoryPath() );
+        stringBuffer.append( File.separator );
+        stringBuffer.append( artifact.getArtifactId() );
+        stringBuffer.append( ".flex.properties" );
+        return stringBuffer.toString();
+    }
+
+    public static final void storeFlexProperties( Properties properties ) {
+
+        storeProperties( properties, getFlexPropertiesPath() );
+    }
+
+    public static final String getFlexPropertiesKey( String prefix, String key ) {
+
+        StringBuffer stringBuffer = new StringBuffer();
+        if ( prefix != null ) {
+            stringBuffer.append( prefix );
+            stringBuffer.append( "." );
+        }
+        stringBuffer.append( key );
+        return stringBuffer.toString();
+    }
+
+    public static final String getFlexProperty( String key ) {
+
+        return (String) getFlexProperties().get( key );
+    }
+
+    public static final String getFlexProperty( String prefix, String key ) {
+
+        key = getFlexPropertiesKey( prefix, key );
+        return (String) getFlexProperties().get( key );
+    }
+}

--- a/src/main/java/org/hardisonbrewing/maven/cxx/flex/PropertiesService.java
+++ b/src/main/java/org/hardisonbrewing/maven/cxx/flex/PropertiesService.java
@@ -26,6 +26,9 @@ import org.hardisonbrewing.maven.cxx.TargetDirectoryService;
 
 public class PropertiesService extends org.hardisonbrewing.maven.cxx.PropertiesService {
 
+    public static final String ADOBE_FLEX_HOME = "adobe.flex.home";
+    public static final String DEBUG = "debug";
+
     private static Properties properties;
 
     protected PropertiesService() {

--- a/src/main/java/org/hardisonbrewing/maven/cxx/flex/SwcCompileMojo.java
+++ b/src/main/java/org/hardisonbrewing/maven/cxx/flex/SwcCompileMojo.java
@@ -29,10 +29,7 @@ import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.cli.Commandline;
 import org.hardisonbrewing.maven.core.FileUtils;
 import org.hardisonbrewing.maven.core.JoJoMojoImpl;
-import org.hardisonbrewing.maven.core.ProjectService;
-import org.hardisonbrewing.maven.core.cli.CommandLineService;
 import org.hardisonbrewing.maven.cxx.TargetDirectoryService;
-import org.hardisonbrewing.maven.cxx.bar.PropertiesService;
 
 /**
  * @goal flex-swc-compile
@@ -44,6 +41,7 @@ public class SwcCompileMojo extends JoJoMojoImpl {
      * @parameter
      */
     private String target;
+
     /**
      * @parameter
      */
@@ -81,37 +79,13 @@ public class SwcCompileMojo extends JoJoMojoImpl {
         cmd.add( "-output" );
         cmd.add( artifactId + ".swc" );
 
-        String sdkHome = PropertiesService.getProperty( PropertiesService.ADOBE_FLEX_HOME );
-
-        StringBuffer configPath = new StringBuffer();
-
-        if ( config != null && config != "" ) {
-
-            configPath.append( ProjectService.getBaseDirPath() );
-            configPath.append( File.separator );
-            configPath.append( config );
-        }
-        else {
-            configPath.append( sdkHome );
-            configPath.append( File.separator );
-            configPath.append( "frameworks" );
-            configPath.append( File.separator );
-            if ( FlexService.isIosTarget( target ) || FlexService.isAndroidTarget( target ) ) {
-                configPath.append( "airmobile-config.xml" );
-            }
-            else {
-                configPath.append( "air-config.xml" );
-            }
-        }
-
-        cmd.add( "-load-config" );
-        cmd.add( configPath.toString() );
+        FlexService.addConfig( cmd, config, target );
 
         cmd.add( "-load-config" );
         cmd.add( resourceConfigPath );
 
         Commandline commandLine = buildCommandline( cmd );
-        CommandLineService.appendEnvVar( commandLine, "PATH", sdkHome + File.separator + "bin" );
+        CommandLineService.addFlexEnvVars( commandLine );
         execute( commandLine );
     }
 

--- a/src/main/java/org/hardisonbrewing/maven/cxx/flex/SwcCompileMojo.java
+++ b/src/main/java/org/hardisonbrewing/maven/cxx/flex/SwcCompileMojo.java
@@ -29,6 +29,7 @@ import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.cli.Commandline;
 import org.hardisonbrewing.maven.core.FileUtils;
 import org.hardisonbrewing.maven.core.JoJoMojoImpl;
+import org.hardisonbrewing.maven.core.ProjectService;
 import org.hardisonbrewing.maven.core.cli.CommandLineService;
 import org.hardisonbrewing.maven.cxx.TargetDirectoryService;
 import org.hardisonbrewing.maven.cxx.bar.PropertiesService;
@@ -43,6 +44,10 @@ public class SwcCompileMojo extends JoJoMojoImpl {
      * @parameter
      */
     private String target;
+    /**
+     * @parameter
+     */
+    private String config;
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
@@ -79,16 +84,26 @@ public class SwcCompileMojo extends JoJoMojoImpl {
         String sdkHome = PropertiesService.getProperty( PropertiesService.ADOBE_FLEX_HOME );
 
         StringBuffer configPath = new StringBuffer();
-        configPath.append( sdkHome );
-        configPath.append( File.separator );
-        configPath.append( "frameworks" );
-        configPath.append( File.separator );
-        if ( FlexService.isIosTarget( target ) || FlexService.isAndroidTarget( target ) ) {
-            configPath.append( "airmobile-config.xml" );
+
+        if ( config != null && config != "" ) {
+
+            configPath.append( ProjectService.getBaseDirPath() );
+            configPath.append( File.separator );
+            configPath.append( config );
         }
         else {
-            configPath.append( "air-config.xml" );
+            configPath.append( sdkHome );
+            configPath.append( File.separator );
+            configPath.append( "frameworks" );
+            configPath.append( File.separator );
+            if ( FlexService.isIosTarget( target ) || FlexService.isAndroidTarget( target ) ) {
+                configPath.append( "airmobile-config.xml" );
+            }
+            else {
+                configPath.append( "air-config.xml" );
+            }
         }
+
         cmd.add( "-load-config" );
         cmd.add( configPath.toString() );
 

--- a/src/main/java/org/hardisonbrewing/maven/cxx/flex/SwfCompileMojo.java
+++ b/src/main/java/org/hardisonbrewing/maven/cxx/flex/SwfCompileMojo.java
@@ -25,10 +25,7 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.codehaus.plexus.util.cli.Commandline;
 import org.hardisonbrewing.maven.core.FileUtils;
 import org.hardisonbrewing.maven.core.JoJoMojoImpl;
-import org.hardisonbrewing.maven.core.ProjectService;
-import org.hardisonbrewing.maven.core.cli.CommandLineService;
 import org.hardisonbrewing.maven.cxx.TargetDirectoryService;
-import org.hardisonbrewing.maven.cxx.bar.PropertiesService;
 
 /**
  * @goal flex-compile
@@ -65,7 +62,9 @@ public class SwfCompileMojo extends JoJoMojoImpl {
         // http://livedocs.adobe.com/flex/3/html/help.html?content=compilers_14.html
         List<String> cmd = new LinkedList<String>();
         cmd.add( "mxmlc" );
+        
         cmd.add( "-keep-generated-actionscript" );
+        
         cmd.add( "-output" );
         cmd.add( swfFilename + ".swf" );
 
@@ -79,31 +78,7 @@ public class SwfCompileMojo extends JoJoMojoImpl {
         actionScriptPath.append( sourceFile );
         cmd.add( actionScriptPath.toString() );
 
-        String sdkHome = PropertiesService.getProperty( PropertiesService.ADOBE_FLEX_HOME );
-
-        StringBuffer configPath = new StringBuffer();
-
-        if ( config != null && config != "" ) {
-
-            configPath.append( ProjectService.getBaseDirPath() );
-            configPath.append( File.separator );
-            configPath.append( config );
-        }
-        else {
-            configPath.append( sdkHome );
-            configPath.append( File.separator );
-            configPath.append( "frameworks" );
-            configPath.append( File.separator );
-            if ( FlexService.isIosTarget( target ) || FlexService.isAndroidTarget( target ) ) {
-                configPath.append( "airmobile-config.xml" );
-            }
-            else {
-                configPath.append( "air-config.xml" );
-            }
-        }
-
-        cmd.add( "-load-config" );
-        cmd.add( configPath.toString() );
+        FlexService.addConfig( cmd, config, target );
 
         String artifactId = getProject().getArtifactId();
         cmd.add( "-include-libraries+=" + artifactId + ".swc" );
@@ -117,7 +92,7 @@ public class SwfCompileMojo extends JoJoMojoImpl {
         }
 
         Commandline commandLine = buildCommandline( cmd );
-        CommandLineService.appendEnvVar( commandLine, "PATH", sdkHome + File.separator + "bin" );
+        CommandLineService.addFlexEnvVars( commandLine );
         execute( commandLine );
     }
 

--- a/src/main/java/org/hardisonbrewing/maven/cxx/flex/SwfCompileMojo.java
+++ b/src/main/java/org/hardisonbrewing/maven/cxx/flex/SwfCompileMojo.java
@@ -25,6 +25,7 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.codehaus.plexus.util.cli.Commandline;
 import org.hardisonbrewing.maven.core.FileUtils;
 import org.hardisonbrewing.maven.core.JoJoMojoImpl;
+import org.hardisonbrewing.maven.core.ProjectService;
 import org.hardisonbrewing.maven.core.cli.CommandLineService;
 import org.hardisonbrewing.maven.cxx.TargetDirectoryService;
 import org.hardisonbrewing.maven.cxx.bar.PropertiesService;
@@ -50,6 +51,11 @@ public class SwfCompileMojo extends JoJoMojoImpl {
      */
     private String target;
 
+    /**
+     * @parameter
+     */
+    private String config;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
 
@@ -59,7 +65,7 @@ public class SwfCompileMojo extends JoJoMojoImpl {
         // http://livedocs.adobe.com/flex/3/html/help.html?content=compilers_14.html
         List<String> cmd = new LinkedList<String>();
         cmd.add( "mxmlc" );
-
+        cmd.add( "-keep-generated-actionscript" );
         cmd.add( "-output" );
         cmd.add( swfFilename + ".swf" );
 
@@ -76,16 +82,26 @@ public class SwfCompileMojo extends JoJoMojoImpl {
         String sdkHome = PropertiesService.getProperty( PropertiesService.ADOBE_FLEX_HOME );
 
         StringBuffer configPath = new StringBuffer();
-        configPath.append( sdkHome );
-        configPath.append( File.separator );
-        configPath.append( "frameworks" );
-        configPath.append( File.separator );
-        if ( FlexService.isIosTarget( target ) || FlexService.isAndroidTarget( target ) ) {
-            configPath.append( "airmobile-config.xml" );
+
+        if ( config != null && config != "" ) {
+
+            configPath.append( ProjectService.getBaseDirPath() );
+            configPath.append( File.separator );
+            configPath.append( config );
         }
         else {
-            configPath.append( "air-config.xml" );
+            configPath.append( sdkHome );
+            configPath.append( File.separator );
+            configPath.append( "frameworks" );
+            configPath.append( File.separator );
+            if ( FlexService.isIosTarget( target ) || FlexService.isAndroidTarget( target ) ) {
+                configPath.append( "airmobile-config.xml" );
+            }
+            else {
+                configPath.append( "air-config.xml" );
+            }
         }
+
         cmd.add( "-load-config" );
         cmd.add( configPath.toString() );
 

--- a/src/main/java/org/hardisonbrewing/maven/cxx/flex/ValidateMojo.java
+++ b/src/main/java/org/hardisonbrewing/maven/cxx/flex/ValidateMojo.java
@@ -19,7 +19,6 @@ package org.hardisonbrewing.maven.cxx.flex;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.hardisonbrewing.maven.core.JoJoMojoImpl;
-import org.hardisonbrewing.maven.cxx.bar.PropertiesService;
 
 /**
  * @goal flex-validate

--- a/src/main/java/org/hardisonbrewing/maven/cxx/xcode/CompileMojo.java
+++ b/src/main/java/org/hardisonbrewing/maven/cxx/xcode/CompileMojo.java
@@ -55,9 +55,9 @@ public final class CompileMojo extends JoJoMojoImpl {
 
         String targetBuildDirPath = getTargetBuildPath( target );
 
-        cmd.add( "SYMROOT=$(PROJECT_DIR)" + targetBuildDirPath );
+        cmd.add( "SYMROOT=$(PROJECT_DIR)" + File.separator + targetBuildDirPath );
 
-        cmd.add( "BUILD_DIR=$(PROJECT_DIR)" + targetBuildDirPath );
+        cmd.add( "BUILD_DIR=$(PROJECT_DIR)" + File.separator + targetBuildDirPath );
 
         String codeSignIdentity = PropertiesService.getXCodeProperty( XCodeService.CODE_SIGN_IDENTITY );
         if ( codeSignIdentity != null ) {
@@ -66,6 +66,7 @@ public final class CompileMojo extends JoJoMojoImpl {
 
         StringBuffer objroot = new StringBuffer();
         objroot.append( "OBJROOT=$(PROJECT_DIR)" );
+        objroot.append( File.separator );
         objroot.append( targetBuildDirPath );
         objroot.append( File.separator );
         objroot.append( "OBJROOT" );

--- a/src/main/java/org/hardisonbrewing/maven/cxx/xcode/GenerateIpaMojo.java
+++ b/src/main/java/org/hardisonbrewing/maven/cxx/xcode/GenerateIpaMojo.java
@@ -84,7 +84,10 @@ public final class GenerateIpaMojo extends JoJoMojoImpl {
 		String codesignAllocateLocation = getCodesignAllocateVariable();
 		if (codesignAllocateLocation == null || codesignAllocateLocation.length() == 0) {
 		
-			codesignAllocateLocation = "/Developer/Platforms/iPhoneOS.platform/Developer/usr/bin/codesign_allocate";
+			/*
+			 * Force to the new Mountain Lion / Xcode 4.5 location
+			 */
+			codesignAllocateLocation = "/Applications/Xcode.app/Contents/Developer/usr/bin/codesign_allocate";
 		}
 
         Commandline commandLine = buildCommandline( cmd );

--- a/src/main/java/org/hardisonbrewing/maven/cxx/xcode/GenerateIpaMojo.java
+++ b/src/main/java/org/hardisonbrewing/maven/cxx/xcode/GenerateIpaMojo.java
@@ -88,7 +88,7 @@ public final class GenerateIpaMojo extends JoJoMojoImpl {
 		}
 
         Commandline commandLine = buildCommandline( cmd );
-        commandLine.addEnvironment( "CODESIGN_ALLOCATE", "/Applications/Xcode.app/Contents/Developer/usr/bin/codesign_allocate" );
+        commandLine.addEnvironment( "CODESIGN_ALLOCATE", codesignAllocateLocation );
         execute( commandLine );
     }
 

--- a/src/main/java/org/hardisonbrewing/maven/cxx/xcode/GenerateIpaMojo.java
+++ b/src/main/java/org/hardisonbrewing/maven/cxx/xcode/GenerateIpaMojo.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.codehaus.plexus.util.cli.CommandLineUtils.StringStreamConsumer;
 import org.codehaus.plexus.util.cli.Commandline;
 import org.hardisonbrewing.maven.core.JoJoMojoImpl;
 
@@ -80,8 +81,14 @@ public final class GenerateIpaMojo extends JoJoMojoImpl {
             cmd.add( provisioningFile.getAbsolutePath() );
         }
 
+		String codesignAllocateLocation = getCodesignAllocateVariable();
+		if (codesignAllocateLocation == null || codesignAllocateLocation.length() == 0) {
+		
+			codesignAllocateLocation = "/Developer/Platforms/iPhoneOS.platform/Developer/usr/bin/codesign_allocate";
+		}
+
         Commandline commandLine = buildCommandline( cmd );
-        commandLine.addEnvironment( "CODESIGN_ALLOCATE", "/Developer/Platforms/iPhoneOS.platform/Developer/usr/bin/codesign_allocate" );
+        commandLine.addEnvironment( "CODESIGN_ALLOCATE", "/Applications/Xcode.app/Contents/Developer/usr/bin/codesign_allocate" );
         execute( commandLine );
     }
 
@@ -93,6 +100,23 @@ public final class GenerateIpaMojo extends JoJoMojoImpl {
         stringBuffer.append( PropertiesService.getTargetProductName( target ) );
         return stringBuffer.toString();
     }
+
+	/**
+	 * Check for the CODESIGN_ALLOCATE variable in the bash profile.
+	 * Mountain Lion's codesign allocate tool is in a different location.
+	 * This assumes that the dev has already set it to the preferred location.
+	 */
+	private String getCodesignAllocateVariable() {
+
+        List<String> cmd = new LinkedList<String>();
+        cmd.add( "echo" );
+        cmd.add( "$CODESIGN_ALLOCATE" );
+
+        StringStreamConsumer streamConsumer = new StringStreamConsumer();
+        execute( cmd, streamConsumer, streamConsumer );
+
+        return streamConsumer.getOutput().trim();
+	}
 
     private String getIpaFilePath( String target ) {
 

--- a/src/main/resources/META-INF/plexus/components.xml
+++ b/src/main/resources/META-INF/plexus/components.xml
@@ -248,7 +248,8 @@
 						<phases>
 							<validate>org.hardisonbrewing:maven-cxx-plugin:validate,
 								org.hardisonbrewing:maven-cxx-plugin:flex-validate</validate>
-							<initialize>org.hardisonbrewing:maven-cxx-plugin:initialize</initialize>
+							<initialize>org.hardisonbrewing:maven-cxx-plugin:initialize,
+								org.hardisonbrewing:maven-cxx-plugin:flex-initialize</initialize>
 							<generate-sources>org.hardisonbrewing:maven-cxx-plugin:dependency-copy,
 								org.hardisonbrewing:maven-cxx-plugin:generate-sources</generate-sources>
 							<process-sources>org.hardisonbrewing:maven-cxx-plugin:process-sources</process-sources>


### PR DESCRIPTION
I made an update so that it checks for the CODESIGN_ALLOCATE bash variable before hard-coding the environment variable. It'll set the environment variable to the preset bash variable if it exists. This may be unnecessary, but I wanted to set it to be sure.

When I tried running your build tool on my Mac, it's using the BourneShell from the plexus-utils project. The BourneShell single quote escapes anything with a pipe or dollar sign in it by default. I copied the BourneShell and modified it in my fork of hbc-maven-core. My fork of hbc-maven-core now uses this new shell (named HBCShell) which doesn't single quote escape pipes or dollar signs. Truthfully, I'm not sure how it ever worked before.

EDIT: You may have to pick my changes; I had forked the metova fork, but I wanted you to have my changes if you wanted them.
